### PR TITLE
Update PHP_CodeSniffer repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This coding standard is used in Brick libraries, but can also be used in your ow
 It is based on [PSR-12](https://www.php-fig.org/psr/psr-12/) and uses
 [Easy Coding Standard](https://github.com/easy-coding-standard/easy-coding-standard) with
 rules cherry-picked from [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer),
-[PHP_CodeSniffer](http://github.com/squizlabs/PHP_CodeSniffer), and the
+[PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer), and the
 [Slevomat coding standard](https://github.com/slevomat/coding-standard).
 
 ## Release process


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932